### PR TITLE
Added support for multiple hosts

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,13 +6,13 @@ Dead simple HTTPS reverse proxy for use when developing
 [![Build Status][travis-badge]][travis]
 
 This utility automatically creates a self-signed certificate, sets up an HTTPS
-server, and proxies all requests to the server you specify. Use it for quickly
+server, and proxies all requests to the server(s) you specify. Use it for quickly
 testing a site over https when developing.
 
 ## Usage
 
 ```sh
-dev-https [-p <port>] <url>
+dev-https [<port>:]<url> [<port2>:]<url2>
 ```
 
 First, you need to install it:
@@ -31,7 +31,13 @@ By default it runs on port 4430 (https://localhost:4430), but you can specify
 the port:
 
 ```sh
-dev-https -p 443 http://localhost:8000
+dev-https 443:http://localhost:8000
+```
+
+You may also specify multiple hosts:
+
+```sh
+dev-https http://localhost:8000 http://localhost:8001
 ```
 
 That's it!

--- a/index.js
+++ b/index.js
@@ -6,13 +6,19 @@ var minimist = require('minimist')
 
 var CERT_OPTIONS = { days: 7, selfSigned: true }
 var args = minimist(process.argv.slice(2))
-if (args.h || args['?'] || args.help || args._.length !== 1) {
-  console.error('Usage: dev-https [-p <port>] <url>')
+if (args.h || args['?'] || args.help || args._.length < 1) {
+  console.error('Usage: dev-https [<port>:]<url> [<port2>:]<url2> …')
   process.exit(1)
 }
 
-var baseUrl = args._[0]
-var port = args.p || 4430
+var port = 4430;
+var hosts = args._.map( (arg) => {
+  var match = arg.match(/^((\d+):)?(.*)/);
+  return {
+    baseUrl: match[3],
+    port: match[2] || port++
+  }
+});
 
 function createCert (callback) {
   pem.createCertificate(CERT_OPTIONS, created)
@@ -29,29 +35,6 @@ function createCert (callback) {
   }
 }
 
-function setupServer (opts, callback) {
-  var server = https.createServer(opts, handler)
-  server.listen(opts.port, callback)
-}
-
-function handler (req, res) {
-  var requestHeaders = {}
-  Object.keys(req.headers).forEach(function (key) {
-    if (key.toLowerCase !== 'host') {
-      requestHeaders[key] = req.headers[key]
-    }
-  })
-
-  var requestOpts = {
-    url: baseUrl + req.url,
-    method: req.method,
-    headers: requestHeaders
-  }
-
-  var proxyReq = request(requestOpts)
-  req.pipe(proxyReq).pipe(res)
-}
-
 createCert(created)
 
 function created (err, cert) {
@@ -59,20 +42,36 @@ function created (err, cert) {
     throw err
   }
 
-  var opts = {
-    key: cert.key,
-    cert: cert.cert,
-    port: port
-  }
+  hosts.forEach( (host, index) => {
+    var opts = {
+      key: cert.key,
+      cert: cert.cert,
+      port: host.port
+    }
+    var server = https.createServer(opts, (req, res) => {
+      var requestHeaders = {}
+      Object.keys(req.headers).forEach( (key) => {
+        if (key.toLowerCase !== 'host') {
+          requestHeaders[key] = req.headers[key]
+        }
+      })
 
-  setupServer(opts, finishedSetup)
+      var requestOpts = {
+        url: host.baseUrl + req.url,
+        method: req.method,
+        headers: requestHeaders
+      }
+
+      var proxyReq = request(requestOpts);
+      req.pipe(proxyReq).pipe(res);
+    });
+    server.listen(opts.port, (err) => {
+      if (err) {
+        console.log(err);
+      }
+      console.log('Listening on https://localhost:' + opts.port);
+      console.log('Proxying requests to ' + host.baseUrl);
+    });
+  });
 }
 
-function finishedSetup (err) {
-  if (err) {
-    throw err
-  }
-
-  console.log('Listening on https://localhost:' + port)
-  console.log('Proxying requests to ' + baseUrl)
-}

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "license": "ISC",
   "dependencies": {
     "minimist": "^1.2.0",
-    "pem": "^1.8.1",
+    "pem": "^1.12.3",
     "request": "^2.65.0"
   },
   "devDependencies": {

--- a/test.js
+++ b/test.js
@@ -10,7 +10,7 @@ test('start and serve requests', function (t) {
 
   function listening (err) {
     t.error(err)
-    proc = spawn(process.execPath, ['index.js', '-p', '8001', 'http://localhost:8000'])
+    proc = spawn(process.execPath, ['index.js', '8001:http://localhost:8000'])
 
     // wait for process to start up
     setTimeout(started, 5000)


### PR DESCRIPTION
You can specify multiple forwards on the command-line. I find this useful because I have multiple api endpoints that https when testing https js.

I'm not sure if I *love* this syntax - `port:http://example.com`