### PR TITLE
updated pem module

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "license": "ISC",
   "dependencies": {
     "minimist": "^1.2.0",
-    "pem": "^1.8.1",
+    "pem": "^1.12.3",
     "request": "^2.65.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Fixes error generating TLS key
```
Error: Invalid openssl exit code: 1
% openssl genrsa -rand /var/log/mail:/var/log/messages 2048
usage: genrsa [args] [numbits]
```